### PR TITLE
Add trailing space to line comment prefixes

### DIFF
--- a/languages/roc/config.toml
+++ b/languages/roc/config.toml
@@ -1,7 +1,7 @@
 name = "Roc"
 grammar = "roc"
 path_suffixes = ["roc"]
-line_comments = ["#", "##"]
+line_comments = ["# ", "## "]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },


### PR DESCRIPTION
This PR adds a trailing space to the line comment prefixes, so that toggling comments in Zed inserts `# ` instead of `#`.

The Roc formatter enforces a space after `#`, adding it after commenting and stripping the leftover one after uncommenting, so saving after toggling a comment shifts the text either way. With the space included, Zed matches the formatted output and removes exactly the right text.

This also matches how most languages in Zed define their comment prefixes, e.g. [Python](https://github.com/zed-industries/zed/blob/main/crates/grammars/src/python/config.toml#L6).