### PR TITLE
Highlight matching parentheses

### DIFF
--- a/languages/roc/brackets.scm
+++ b/languages/roc/brackets.scm
@@ -1,0 +1,3 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)


### PR DESCRIPTION
_Almost just straight from the [docs](https://zed.dev/docs/extensions/languages#bracket-matching)_ 