### PR TITLE
Update Roc grammar dependency

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -9,7 +9,7 @@ languages = ["languages/roc"]
 
 [grammars.roc]
 repository = "https://github.com/faldor20/tree-sitter-roc"
-commit = "fc80e44f452314518550d947bcfdde6c3001a405"
+commit = "d91c4e8c972ad8aac03fa45414a11f564c2274e3"
 
 [language_servers.roc]
 language = "Roc"


### PR DESCRIPTION
Updates the Roc Tree-sitter grammar `d91c4e8c972ad8aac03fa45414a11f564c2274e3` -- QA by looking through various files. 

<img width="1562" height="433" alt="Screenshot from 2026-08-22 08-19-15" src="https://github.com/user-attachments/assets/c09d4580-d3d2-4769-b3cc-03879cb95981" />
